### PR TITLE
fix: Correct import to work on modern Python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 
 setup(
     name='SRFax',
-    version='0.1.2',
+    version='0.1.3',
     description='SRFax (www.srfax.com) API library',
     long_description=open('README.rst').read(),
     author='Andjelko Horvat',

--- a/srfax/srfax.py
+++ b/srfax/srfax.py
@@ -10,6 +10,7 @@ import base64
 import logging
 
 import suds
+import suds.client
 
 
 URL = 'https://www.srfax.com/SRF_UserFaxWebSrv.php?wsdl'


### PR DESCRIPTION
Newer Python versions couldn't find the suds.client package automatically. Needed to import it directly for it to work.